### PR TITLE
chore(dependencies): update pmuir/project2 from 0.0.8 to 0.0.9

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,6 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[pmuir/project2](https://github.com/pmuir/project2) |  | [0.0.9](https://github.com/pmuir/project2/releases/tag/v0.0.9) | 
+[pmuir/project1](https://github.com/pmuir/project1) |  | [0.0.6](https://github.com/pmuir/project1/releases/tag/v0.0.6) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,13 @@
+dependencies:
+- host: github.com
+  owner: pmuir
+  repo: project2
+  url: https://github.com/pmuir/project2
+  version: 0.0.9
+  versionURL: https://github.com/pmuir/project2/releases/tag/v0.0.9
+- host: github.com
+  owner: pmuir
+  repo: project1
+  url: https://github.com/pmuir/project1
+  version: 0.0.6
+  versionURL: https://github.com/pmuir/project1/releases/tag/v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/pmuir/project3
 
 go 1.12
 
-require github.com/pmuir/project2 v0.0.8 // indirect
+require github.com/pmuir/project2 v0.0.9 // indirect


### PR DESCRIPTION
Update [pmuir/project2](https://github.com/pmuir/project2) from [0.0.8](https://github.com/pmuir/project2/releases/tag/v0.0.8) to [0.0.9](https://github.com/pmuir/project2/releases/tag/v0.0.9)

Command run was `/Users/pmuir/go/src/github.com/jenkins-x/jx/build/jx step create pr regex --repo https://github.com/pmuir/project3 --regex ^require github\.com\/pmuir\/project2 v([\d\.]*).*$ --version 0.0.9 --files go.mod`