### PR TITLE
chore(deps): bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PKGS := $(subst  :,_,$(PKGS))
 BUILDFLAGS := ''
 CGO_ENABLED = 0
 VENDOR_DIR=vendor
-PROJECT2_VERSION := 0.0.1
+PROJECT2_VERSION := 0.0.2
 
 all: build
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PKGS := $(subst  :,_,$(PKGS))
 BUILDFLAGS := ''
 CGO_ENABLED = 0
 VENDOR_DIR=vendor
-PROJECT2_VERSION := 0.0.2
+PROJECT2_VERSION := 0.0.3
 
 all: build
 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[pmuir/project2](https://github.com/pmuir/project2) |  | [0.0.9](https://github.com/pmuir/project2/releases/tag/v0.0.9) | 
+[pmuir/project2](https://github.com/pmuir/project2) |  | [0.0.2](https://github.com/pmuir/project2/releases/tag/v0.0.2) | 
 [pmuir/project1](https://github.com/pmuir/project1) | [github.com/pmuir/project2](https://github.com/pmuir/project2) | [0.0.6](https://github.com/pmuir/project1/releases/tag/v0.0.6) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[pmuir/project2](https://github.com/pmuir/project2) |  | [0.0.2](https://github.com/pmuir/project2/releases/tag/v0.0.2) | 
+[pmuir/project2](https://github.com/pmuir/project2) |  | [0.0.3](https://github.com/pmuir/project2/releases/tag/v0.0.3) | 
 [pmuir/project1](https://github.com/pmuir/project1) | [github.com/pmuir/project2](https://github.com/pmuir/project2) | [0.0.6](https://github.com/pmuir/project1/releases/tag/v0.0.6) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: pmuir
   repo: project2
   url: https://github.com/pmuir/project2
-  version: 0.0.2
-  versionURL: https://github.com/pmuir/project2/releases/tag/v0.0.2
+  version: 0.0.3
+  versionURL: https://github.com/pmuir/project2/releases/tag/v0.0.3
 - host: github.com
   owner: pmuir
   repo: project1

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: pmuir
   repo: project2
   url: https://github.com/pmuir/project2
-  version: 0.0.9
-  versionURL: https://github.com/pmuir/project2/releases/tag/v0.0.9
+  version: 0.0.2
+  versionURL: https://github.com/pmuir/project2/releases/tag/v0.0.2
 - host: github.com
   owner: pmuir
   repo: project1


### PR DESCRIPTION
Update [pmuir/project2](https://github.com/pmuir/project2) from [0.0.1](https://github.com/pmuir/project2/releases/tag/v0.0.1) to [0.0.3](https://github.com/pmuir/project2/releases/tag/v0.0.3)

Command run was `/Users/pmuir/go/src/github.com/jenkins-x/jx/build/jx step create pr make --name PROJECT2_VERSION --version 0.0.3 --repo https://github.com/pmuir/project3.git`
<hr />

Update [pmuir/project2](https://github.com/pmuir/project2) from [0.0.1](https://github.com/pmuir/project2/releases/tag/v0.0.1) to [0.0.3](https://github.com/pmuir/project2/releases/tag/v0.0.3)

Command run was `/Users/pmuir/go/src/github.com/jenkins-x/jx/build/jx step create pr make --name PROJECT2_VERSION --version 0.0.3 --repo https://github.com/pmuir/project3.git`
<hr />

Update [pmuir/project2](https://github.com/pmuir/project2) from [0.0.1](https://github.com/pmuir/project2/releases/tag/v0.0.1) to [0.0.3](https://github.com/pmuir/project2/releases/tag/v0.0.3)

Command run was `/Users/pmuir/go/src/github.com/jenkins-x/jx/build/jx step create pr make --name PROJECT2_VERSION --version 0.0.3 --repo https://github.com/pmuir/project3.git`
<hr />

Update [pmuir/project2](https://github.com/pmuir/project2) from [0.0.1](https://github.com/pmuir/project2/releases/tag/v0.0.1) to [0.0.2](https://github.com/pmuir/project2/releases/tag/v0.0.2)

Command run was `jx step create pr make --name PROJECT2_VERSION --version 0.0.2 --repo https://github.com/pmuir/project3.git`